### PR TITLE
"database configuration does not specify adapter" on production-only installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Clone the plugin source code into your Redmine's plugin directory.
 
 Copy plugin assets to a public directory.
 
-    rake redmine:plugins:assets
+    RAILS_ENV="production" rake redmine:plugins:assets
 
 Setup
 -----


### PR DESCRIPTION
End users work on production. I had to google this,
